### PR TITLE
Added runtime parameter to open java.net

### DIFF
--- a/src/main/resources/archetype-resources/application/pom.xml
+++ b/src/main/resources/archetype-resources/application/pom.xml
@@ -17,9 +17,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <all.clusters>${D}{project.build.directory}/${D}{brandingToken}</all.clusters>
+
+        <netbeans.run.params.local/>
+        <netbeans.run.params.ide/>
+        <netbeans.run.params>${netbeans.run.params.ide} ${netbeans.run.params.local} -J--add-opens=java.base/java.net=ALL-UNNAMED</netbeans.run.params>
         <jpms-flags>
             --add-opens=java.base/java.net=ALL-UNNAMED
-            <!-- add more "add opens" if needed -->
+            <!-- add more "add opens" if needed. Note that it must be added to netbeans.run.params if needed at runtime -->
         </jpms-flags>
     </properties>
 


### PR DESCRIPTION
The archetype has jpms flag to build with `--add-opens=java.base/java.net=ALL-UNNAMED` but running the application throws an exception at startup for not being able to access `java.base`

```
SEVERE: No way to find original stream handler for jar protocol
java.lang.reflect.InaccessibleObjectException: Unable to make field transient java.net.URLStreamHandler java.net.URL.handler accessible: module java.base does not "opens java.net" to unnamed module @3b07d329
	at java.base/java.lang.reflect.AccessibleObject.throwInaccessibleObjectException(AccessibleObject.java:353)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:329)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:277)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:179)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:173)
	at org.netbeans.ProxyURLStreamHandlerFactory.register(ProxyURLStreamHandlerFactory.java:59)
	at org.netbeans.JarClassLoader.<clinit>(JarClassLoader.java:143)
	at org.netbeans.MainImpl.execute(MainImpl.java:166)
	at org.netbeans.MainImpl.main(MainImpl.java:60)
	at org.netbeans.Main.main(Main.java:58)
```

The change opens the module at runtime successfully. There may be a more elegant way to achieve the same, happy to learn about it if there's one!